### PR TITLE
Update new_handler.cpp

### DIFF
--- a/src/new_handler.cpp
+++ b/src/new_handler.cpp
@@ -19,7 +19,7 @@
 
 #include "new"
 
-const std::nothrow_t std::nothrow = { };
+//const std::nothrow_t std::nothrow = { };
 
 //Name selected to be compatable with g++ code
 std::new_handler __new_handler;


### PR DESCRIPTION
removed line //const std::nothrow_t std::nothrow = { }; to prevent compile error, Arduino IDE 2.3.3